### PR TITLE
Make get and set urls configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,31 @@ tpc(enabled => {
 })
 ```
 
+#### Overriding default urls for cookie setting and getting
+
+```js
+import tpc from 'tpc-check'
+
+tpc(enabled => {
+  if (!enabled) {
+    alert('Please, enable third-party cookies to proceed')
+  }
+}, {
+  getCookieUrl: 'http://my-domain.com/get-cookie.js',
+  setCookieUrl: 'http://my-domain.com/set-cookie.js',
+})
+```
+
+Here the get-cookie.js contains:
+```js
+window.triggerTPCCallback(true)
+```
+
+And set-cookie.js contains:
+```js
+window.loadTPCScript()
+```
+
 ### Development and Contribution
 
 If you discovered a bug or have a feature suggestion, feel free to create an

--- a/src/Checker.js
+++ b/src/Checker.js
@@ -1,11 +1,13 @@
 import { addScript, removeScript } from './utils'
 
 const BASE_URL = 'https://2plexv84m5.execute-api.us-east-1.amazonaws.com/prod'
-const SET_COOKIE_URL = `${BASE_URL}/set-third-party-cookie.js`
-const GET_COOKIE_URL = `${BASE_URL}/get-third-party-cookie.js`
+const DEFAULT_SET_COOKIE_URL = `${BASE_URL}/set-third-party-cookie.js`
+const DEFAULT_GET_COOKIE_URL = `${BASE_URL}/get-third-party-cookie.js`
 
 export default class Checker {
-  constructor(callback) {
+  constructor(callback, options={}) {
+    this.setCookieUrl = options.setCookieUrl || DEFAULT_SET_COOKIE_URL
+    this.getCookieUrl = options.getCookieUrl || DEFAULT_GET_COOKIE_URL
     this.callback = callback
     this.scripts = {
       load: null,
@@ -31,7 +33,7 @@ export default class Checker {
    */
   initializeTrigger() {
     this.listenTrigger()
-    this.scripts.trigger = addScript(GET_COOKIE_URL)
+    this.scripts.trigger = addScript(this.getCookieUrl)
   }
 
   /**
@@ -52,7 +54,7 @@ export default class Checker {
    */
   initializeLoad() {
     this.listenLoad()
-    this.scripts.load = addScript(SET_COOKIE_URL)
+    this.scripts.load = addScript(this.setCookieUrl)
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 import Checker from './Checker'
 
-export default function tpc(callback) {
+export default function tpc(callback, options={}) {
   if (!callback) {
     throw new Error('Please provide callback')
   }
 
-  return new Checker(callback).execute()
+  return new Checker(callback, options).execute()
 }


### PR DESCRIPTION
Our use-case involves heavy traffic (billions of requests per month) and we would prefer not to hammer your end-point that you've generously provided with that much traffic. So this change makes the urls configurable. Let me know your thoughts!